### PR TITLE
enhanced timestampToRelativeTime function

### DIFF
--- a/internal/glance/static/js/main.js
+++ b/internal/glance/static/js/main.js
@@ -46,38 +46,42 @@ function setupCarousels() {
     }
 }
 
-const minuteInSeconds = 60;
-const hourInSeconds = minuteInSeconds * 60;
-const dayInSeconds = hourInSeconds * 24;
-const monthInSeconds = dayInSeconds * 30.4;
-const yearInSeconds = dayInSeconds * 365;
+const TIME_UNITS = [
+    ["y", 31536000],
+    ["mo", 2592000],
+    ["w", 604800],
+    ["d", 86400],
+    ["h", 3600],
+    ["m", 60],
+    ["s", 1],
+];
 
-function timestampToRelativeTime(timestamp) {
-    let delta = Math.round((Date.now() / 1000) - timestamp);
-    let prefix = "";
+function timestampToRelativeTime(timestamp, units = 1, relative = true)
+{
+    if (!Number.isFinite(timestamp)) return "Invalid";
+    if (units < 1) units = 1;
 
-    if (delta < 0) {
-        delta = -delta;
-        prefix = "in ";
+    const now = Math.floor(Date.now() / 1000);
+    const diff = now - timestamp;
+    const isInFuture = diff < 0;
+    const absDiff = Math.abs(diff);
+
+    if (absDiff < 1) return relative ? "just now" : "0s";
+
+    const parts = [];
+    let remaining = Math.floor(absDiff);
+
+    for (const [label, seconds] of TIME_UNITS)
+    {
+        if (remaining >= seconds && parts.length < units) {
+            const count = Math.floor(remaining / seconds);
+            parts.push(`${count}${label}`);
+            remaining %= seconds;
+        }
     }
 
-    if (delta < minuteInSeconds) {
-        return prefix + "1m";
-    }
-    if (delta < hourInSeconds) {
-        return prefix + Math.floor(delta / minuteInSeconds) + "m";
-    }
-    if (delta < dayInSeconds) {
-        return prefix + Math.floor(delta / hourInSeconds) + "h";
-    }
-    if (delta < monthInSeconds) {
-        return prefix + Math.floor(delta / dayInSeconds) + "d";
-    }
-    if (delta < yearInSeconds) {
-        return prefix + Math.floor(delta / monthInSeconds) + "mo";
-    }
-
-    return prefix + Math.floor(delta / yearInSeconds) + "y";
+    const timeStr = parts.join(" ");
+    return relative ? (isInFuture ? `in ${timeStr}` : `${timeStr} ago`) : timeStr;
 }
 
 function updateRelativeTimeForElements(elements)
@@ -85,12 +89,16 @@ function updateRelativeTimeForElements(elements)
     for (let i = 0; i < elements.length; i++)
     {
         const element = elements[i];
-        const timestamp = element.dataset.dynamicRelativeTime;
+        const timestamp = Number(element.dataset.dynamicRelativeTime);
+        if (!timestamp) continue;
 
-        if (timestamp === undefined)
-            continue
+        const units = element.dataset.units || 1;
+        const relative = element.dataset.showRelative === "true";
 
-        element.textContent = timestampToRelativeTime(timestamp);
+        const formattedTime = timestampToRelativeTime(timestamp, Number(units), relative);
+        if (element.textContent !== formattedTime) {
+            element.textContent = formattedTime;
+        }
     }
 }
 
@@ -206,7 +214,7 @@ function setupSearchBoxes() {
 
 function setupDynamicRelativeTime() {
     const elements = document.querySelectorAll("[data-dynamic-relative-time]");
-    const updateInterval = 60 * 1000;
+    const updateInterval = 1000;
     let lastUpdateTime = Date.now();
 
     updateRelativeTimeForElements(elements);


### PR DESCRIPTION
## Major Changes

**Time Unit Definition**
Added a structured `TIME_UNITS` array to replace individual constants

**Enhanced** `function timestampToRelativeTime`
- Added two new parameters:
	- `units`: Controls how many time units to display (default: 1)
	- `relative`: Controls whether to show "ago"/"in" text (default: true)
- Added support for "just now" for very recent timestamps
- Added multi-unit display support (e.g., "1y 2mo" instead of just "1y")

**Updated** `function updateRelativeTimeForElements`

- Added support for configurable units via data-units attribute
- Added data-show-relative attribute support
- Added value comparison to prevent unnecessary DOM updates

📝 Example Usage Changes

New format with options:
```html
<span data-dynamic-relative-time="1632512400">
	1y

<span data-dynamic-relative-time="1754520520" data-show-relative="true">
	in 4mo

<span data-dynamic-relative-time="1632512400" data-show-relative="true" data-units="2">
	1y 2mo ago


<span data-dynamic-relative-time="1734020520" data-show-relative="true" data-units="6">
	3mo 1w 4d 1h 42m 31s ago
```

## Breaking Changes

Update frequency is more aggressive (1s vs 60s)

These changes provide more flexibility and precision in time display while maintaining backward compatibility with existing implementations.